### PR TITLE
Support for statistics callback

### DIFF
--- a/src/Client/Producer/ProducerClient.php
+++ b/src/Client/Producer/ProducerClient.php
@@ -124,6 +124,9 @@ class ProducerClient
         }
     }
 
+    /**
+     * @param mixed $data
+     */
     private function getPartition($data, ProducerInterface $producer, ResolvedConfiguration $configuration): int
     {
         if (!$producer instanceof PartitionAwareProducerInterface) {

--- a/src/Configuration/Type/StatisticsIntervalMs.php
+++ b/src/Configuration/Type/StatisticsIntervalMs.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StsGamingGroup\KafkaBundle\Configuration\Type;
+
+use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+class StatisticsIntervalMs implements ConsumerConfigurationInterface, KafkaConfigurationInterface
+{
+    public const NAME = 'statistics_interval_ms';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function getKafkaProperty(): string
+    {
+        return 'statistics.interval.ms';
+    }
+
+    public function getMode(): int
+    {
+        return InputOption::VALUE_REQUIRED;
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            <<<EOT
+            The frequency in milliseconds that the internal rdkafka statistics are sent to client.
+            Defaults to %s ms. Set 0 to disable.
+            EOT,
+            $this->getDefaultValue()
+        );
+    }
+
+    public function isValueValid($value): bool
+    {
+        return is_numeric($value) && strpos((string) $value, '.') === false && $value >= 0;
+    }
+
+    public function getDefaultValue(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @param mixed $validatedValue
+     */
+    public function cast($validatedValue): int
+    {
+        return (int) $validatedValue;
+    }
+}

--- a/src/Configuration/Type/StatisticsIntervalMs.php
+++ b/src/Configuration/Type/StatisticsIntervalMs.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
+use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
 use Symfony\Component\Console\Input\InputOption;
 
-class StatisticsIntervalMs implements ConsumerConfigurationInterface, KafkaConfigurationInterface
+class StatisticsIntervalMs implements ConsumerConfigurationInterface, KafkaConfigurationInterface, CastValueInterface
 {
     public const NAME = 'statistics_interval_ms';
 
@@ -48,9 +49,6 @@ class StatisticsIntervalMs implements ConsumerConfigurationInterface, KafkaConfi
         return 0;
     }
 
-    /**
-     * @param mixed $validatedValue
-     */
     public function cast($validatedValue): int
     {
         return (int) $validatedValue;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ use StsGamingGroup\KafkaBundle\Configuration\Type\RegisterMissingSubjects;
 use StsGamingGroup\KafkaBundle\Configuration\Type\RetryDelay;
 use StsGamingGroup\KafkaBundle\Configuration\Type\RetryMultiplier;
 use StsGamingGroup\KafkaBundle\Configuration\Type\SchemaRegistry;
+use StsGamingGroup\KafkaBundle\Configuration\Type\StatisticsIntervalMs;
 use StsGamingGroup\KafkaBundle\Configuration\Type\Timeout;
 use StsGamingGroup\KafkaBundle\Configuration\Type\Topics;
 use StsGamingGroup\KafkaBundle\Configuration\Type\Validators;
@@ -95,6 +96,9 @@ class Configuration implements ConfigurationInterface
             ->integerNode(LogLevel::NAME)
                 ->defaultValue((new LogLevel)->getDefaultValue())
             ->end()
+            ->integerNode(StatisticsIntervalMs::NAME)
+                ->defaultValue((new StatisticsIntervalMs)->getDefaultValue())
+            ->end()
             ->arrayNode(Brokers::NAME)
                 ->defaultValue((new Brokers)->getDefaultValue())
                 ->cannotBeEmpty()
@@ -135,6 +139,9 @@ class Configuration implements ConfigurationInterface
             ->scalarNode(AutoCommitIntervalMs::NAME)
                 ->defaultValue((new AutoCommitIntervalMs)->getDefaultValue())
                 ->cannotBeEmpty()
+            ->end()
+            ->integerNode(StatisticsIntervalMs::NAME)
+                ->defaultValue((new StatisticsIntervalMs)->getDefaultValue())
             ->end()
             ->scalarNode(AutoOffsetReset::NAME)
                 ->defaultValue((new AutoOffsetReset)->getDefaultValue())

--- a/src/Resources/config/configuration_types.xml
+++ b/src/Resources/config/configuration_types.xml
@@ -25,6 +25,10 @@
                  id="sts_gaming_group_kafka.configuration.type.auto_commit_interval_ms">
             <tag name="sts_gaming_group_kafka.configuration.type"/>
         </service>
+        <service class="StsGamingGroup\KafkaBundle\Configuration\Type\StatisticsIntervalMs"
+                 id="sts_gaming_group_kafka.configuration.type.statistics_interval_ms">
+            <tag name="sts_gaming_group_kafka.configuration.type"/>
+        </service>
         <service class="StsGamingGroup\KafkaBundle\Configuration\Type\Decoder" id="sts_gaming_group_kafka.configuration.type.decoder">
             <tag name="sts_gaming_group_kafka.configuration.type"/>
         </service>

--- a/tests/Unit/Configuration/Type/StatisticsIntervalMsTest.php
+++ b/tests/Unit/Configuration/Type/StatisticsIntervalMsTest.php
@@ -16,7 +16,7 @@ class StatisticsIntervalMsTest extends AbstractConfigurationTest
 
     protected function getValidValues(): array
     {
-        return ['1', 2, 1000, 5000, 30000, 100000];
+        return ['1', 2, 1000, '1000', 5000, 30000, 100000];
     }
 
     protected function getInvalidValues(): array

--- a/tests/Unit/Configuration/Type/StatisticsIntervalMsTest.php
+++ b/tests/Unit/Configuration/Type/StatisticsIntervalMsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StsGamingGroup\KafkaBundle\Tests\Unit\Configuration\Type;
+
+use StsGamingGroup\KafkaBundle\Configuration\Contract\ConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Type\StatisticsIntervalMs;
+
+class StatisticsIntervalMsTest extends AbstractConfigurationTest
+{
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new StatisticsIntervalMs();
+    }
+
+    protected function getValidValues(): array
+    {
+        return ['1', 2, 1000, 5000, 30000, 100000];
+    }
+
+    protected function getInvalidValues(): array
+    {
+        return [-1, '-1', 1.51, '2.55', '', [], null, new \stdClass(), false, true];
+    }
+}


### PR DESCRIPTION
Basic support for STATISTICS_CALLBACK / setStatsCb callback. Abbility to set `statistics_interval_ms` (which is translated to kafka statistics.interval.ms) is required to make it work.