### PR TITLE
patch for configs to divide producer and consumer configs

### DIFF
--- a/src/Configuration/ConfigurationResolver.php
+++ b/src/Configuration/ConfigurationResolver.php
@@ -34,6 +34,10 @@ class ConfigurationResolver
         $configuration = new ResolvedConfiguration();
 
         foreach ($this->rawConfiguration->getConfigurations() as $rawConfiguration) {
+            if (is_object($clientClass) && !$rawConfiguration->supportsClient($clientClass)) {
+                continue;
+            }
+
             $resolvedValue = $this->getResolvedValue($rawConfiguration, $clientClass, $input);
 
             if ($rawConfiguration instanceof CastValueInterface) {

--- a/src/Configuration/Contract/ConfigurationInterface.php
+++ b/src/Configuration/Contract/ConfigurationInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace StsGamingGroup\KafkaBundle\Configuration\Contract;
 
+use StsGamingGroup\KafkaBundle\Client\Contract\ClientInterface;
+
 interface ConfigurationInterface
 {
     public function getName(): string;
@@ -19,4 +21,6 @@ interface ConfigurationInterface
      * @return mixed
      */
     public function getDefaultValue();
+
+    public function supportsClient(ClientInterface $client): bool;
 }

--- a/src/Configuration/Traits/SupportsConsumerTrait.php
+++ b/src/Configuration/Traits/SupportsConsumerTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace StsGamingGroup\KafkaBundle\Configuration\Traits;
+
+use ReflectionClass;
+use StsGamingGroup\KafkaBundle\Client\Contract\ClientInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ConsumerInterface;
+
+trait SupportsConsumerTrait
+{
+    public function supportsClient(ClientInterface $client): bool
+    {
+        $clientRef = new ReflectionClass($client::class);
+
+        return $clientRef->implementsInterface(ConsumerInterface::class);
+    }
+}

--- a/src/Configuration/Traits/SupportsProducerTrait.php
+++ b/src/Configuration/Traits/SupportsProducerTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace StsGamingGroup\KafkaBundle\Configuration\Traits;
+
+use ReflectionClass;
+use StsGamingGroup\KafkaBundle\Client\Contract\ClientInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ProducerInterface;
+
+trait SupportsProducerTrait
+{
+    public function supportsClient(ClientInterface $client): bool
+    {
+        $clientRef = new ReflectionClass($client::class);
+
+        return $clientRef->implementsInterface(ProducerInterface::class);
+    }
+}

--- a/src/Configuration/Type/AutoCommitIntervalMs.php
+++ b/src/Configuration/Type/AutoCommitIntervalMs.php
@@ -6,10 +6,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class AutoCommitIntervalMs implements ConsumerConfigurationInterface, KafkaConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'auto_commit_interval_ms';
 
     public function getName(): string

--- a/src/Configuration/Type/AutoOffsetReset.php
+++ b/src/Configuration/Type/AutoOffsetReset.php
@@ -6,10 +6,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class AutoOffsetReset implements ConsumerConfigurationInterface, KafkaConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'auto_offset_reset';
     public const SMALLEST = 'smallest';
     public const LARGEST = 'largest';

--- a/src/Configuration/Type/Brokers.php
+++ b/src/Configuration/Type/Brokers.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
-use StsGamingGroup\KafkaBundle\Configuration\Contract\ConfigurationInterface;
+use ReflectionClass;
+use StsGamingGroup\KafkaBundle\Client\Contract\ClientInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ConsumerInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ProducerInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ProducerConfigurationInterface;
@@ -52,5 +55,13 @@ class Brokers implements KafkaConfigurationInterface, ConsumerConfigurationInter
     public function getDefaultValue(): array
     {
         return ['127.0.0.1', '127.0.0.2'];
+    }
+
+    public function supportsClient(ClientInterface $client): bool
+    {
+        $clientRef = new ReflectionClass($client::class);
+
+        return $clientRef->implementsInterface(ConsumerInterface::class)
+            || $clientRef->implementsInterface(ProducerInterface::class);
     }
 }

--- a/src/Configuration/Type/Decoder.php
+++ b/src/Configuration/Type/Decoder.php
@@ -6,6 +6,7 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\ObjectConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use StsGamingGroup\KafkaBundle\Decoder\AvroDecoder;
 use StsGamingGroup\KafkaBundle\Decoder\Contract\DecoderInterface;
 use StsGamingGroup\KafkaBundle\Decoder\JsonDecoder;
@@ -14,6 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class Decoder implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use ObjectConfigurationTrait;
 
     public const NAME = 'decoder';

--- a/src/Configuration/Type/Denormalizer.php
+++ b/src/Configuration/Type/Denormalizer.php
@@ -6,12 +6,14 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\ObjectConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use StsGamingGroup\KafkaBundle\Denormalizer\Contract\DenormalizerInterface;
 use StsGamingGroup\KafkaBundle\Denormalizer\PlainDenormalizer;
 use Symfony\Component\Console\Input\InputOption;
 
 class Denormalizer implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use ObjectConfigurationTrait;
 
     public const NAME = 'denormalizer';

--- a/src/Configuration/Type/EnableAutoCommit.php
+++ b/src/Configuration/Type/EnableAutoCommit.php
@@ -7,9 +7,11 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\BooleanConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 
 class EnableAutoCommit implements KafkaConfigurationInterface, ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use BooleanConfigurationTrait;
 
     public const NAME = 'enable_auto_commit';

--- a/src/Configuration/Type/EnableAutoOffsetStore.php
+++ b/src/Configuration/Type/EnableAutoOffsetStore.php
@@ -7,9 +7,11 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\BooleanConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 
 class EnableAutoOffsetStore implements KafkaConfigurationInterface, ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use BooleanConfigurationTrait;
 
     public const NAME = 'enable_auto_offset_store';

--- a/src/Configuration/Type/GroupId.php
+++ b/src/Configuration/Type/GroupId.php
@@ -6,10 +6,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class GroupId implements KafkaConfigurationInterface, ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'group_id';
 
     public function getName(): string

--- a/src/Configuration/Type/LogLevel.php
+++ b/src/Configuration/Type/LogLevel.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
+use ReflectionClass;
+use StsGamingGroup\KafkaBundle\Client\Contract\ClientInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ConsumerInterface;
+use StsGamingGroup\KafkaBundle\Client\Contract\ProducerInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
@@ -50,5 +54,13 @@ class LogLevel implements KafkaConfigurationInterface, ConsumerConfigurationInte
     public function getDefaultValue(): int
     {
         return LOG_ERR;
+    }
+
+    public function supportsClient(ClientInterface $client): bool
+    {
+        $clientRef = new ReflectionClass($client::class);
+
+        return $clientRef->implementsInterface(ConsumerInterface::class)
+            || $clientRef->implementsInterface(ProducerInterface::class);
     }
 }

--- a/src/Configuration/Type/MaxRetries.php
+++ b/src/Configuration/Type/MaxRetries.php
@@ -6,10 +6,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class MaxRetries implements ConsumerConfigurationInterface, CastValueInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'max_retries';
 
     public function getName(): string

--- a/src/Configuration/Type/MaxRetryDelay.php
+++ b/src/Configuration/Type/MaxRetryDelay.php
@@ -6,10 +6,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class MaxRetryDelay implements ConsumerConfigurationInterface, CastValueInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'max_retry_delay';
 
     public function getName(): string

--- a/src/Configuration/Type/ProducerPartition.php
+++ b/src/Configuration/Type/ProducerPartition.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ProducerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsProducerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class ProducerPartition implements ProducerConfigurationInterface
 {
+    use SupportsProducerTrait;
+
     public const NAME = 'producer_partition';
 
     public function getName(): string

--- a/src/Configuration/Type/ProducerTopic.php
+++ b/src/Configuration/Type/ProducerTopic.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ProducerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsProducerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class ProducerTopic implements ProducerConfigurationInterface
 {
+    use SupportsProducerTrait;
+
     public const NAME = 'producer_topic';
 
     public function getName(): string

--- a/src/Configuration/Type/RegisterMissingSchemas.php
+++ b/src/Configuration/Type/RegisterMissingSchemas.php
@@ -7,9 +7,11 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 use FlixTech\AvroSerializer\Objects\RecordSerializer;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\BooleanConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 
 class RegisterMissingSchemas implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use BooleanConfigurationTrait;
 
     public const NAME = RecordSerializer::OPTION_REGISTER_MISSING_SCHEMAS;

--- a/src/Configuration/Type/RegisterMissingSubjects.php
+++ b/src/Configuration/Type/RegisterMissingSubjects.php
@@ -7,9 +7,11 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 use FlixTech\AvroSerializer\Objects\RecordSerializer;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\BooleanConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 
 class RegisterMissingSubjects implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use BooleanConfigurationTrait;
 
     public const NAME = RecordSerializer::OPTION_REGISTER_MISSING_SUBJECTS;

--- a/src/Configuration/Type/RetryDelay.php
+++ b/src/Configuration/Type/RetryDelay.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class RetryDelay implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'retry_delay';
 
     public function getName(): string

--- a/src/Configuration/Type/RetryMultiplier.php
+++ b/src/Configuration/Type/RetryMultiplier.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class RetryMultiplier implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'retry_multiplier';
 
     public function getName(): string

--- a/src/Configuration/Type/SchemaRegistry.php
+++ b/src/Configuration/Type/SchemaRegistry.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class SchemaRegistry implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'schema_registry';
 
     public function getName(): string

--- a/src/Configuration/Type/StatisticsIntervalMs.php
+++ b/src/Configuration/Type/StatisticsIntervalMs.php
@@ -7,10 +7,13 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\KafkaConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class StatisticsIntervalMs implements ConsumerConfigurationInterface, KafkaConfigurationInterface, CastValueInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'statistics_interval_ms';
 
     public function getName(): string

--- a/src/Configuration/Type/Timeout.php
+++ b/src/Configuration/Type/Timeout.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\CastValueInterface;
-use StsGamingGroup\KafkaBundle\Configuration\Contract\ConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class Timeout implements ConsumerConfigurationInterface, CastValueInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'timeout';
 
     public function getName(): string

--- a/src/Configuration/Type/Topics.php
+++ b/src/Configuration/Type/Topics.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
-use StsGamingGroup\KafkaBundle\Configuration\Contract\ConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use Symfony\Component\Console\Input\InputOption;
 
 class Topics implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
+
     public const NAME = 'topics';
 
     public function getName(): string

--- a/src/Configuration/Type/Validators.php
+++ b/src/Configuration/Type/Validators.php
@@ -6,12 +6,14 @@ namespace StsGamingGroup\KafkaBundle\Configuration\Type;
 
 use StsGamingGroup\KafkaBundle\Configuration\Contract\ConsumerConfigurationInterface;
 use StsGamingGroup\KafkaBundle\Configuration\Traits\ObjectConfigurationTrait;
+use StsGamingGroup\KafkaBundle\Configuration\Traits\SupportsConsumerTrait;
 use StsGamingGroup\KafkaBundle\Validator\Contract\ValidatorInterface;
 use StsGamingGroup\KafkaBundle\Validator\Type\PlainValidator;
 use Symfony\Component\Console\Input\InputOption;
 
 class Validators implements ConsumerConfigurationInterface
 {
+    use SupportsConsumerTrait;
     use ObjectConfigurationTrait;
 
     public const NAME = 'validators';

--- a/tests/Unit/Configuration/ConfigurationResolverTest.php
+++ b/tests/Unit/Configuration/ConfigurationResolverTest.php
@@ -43,6 +43,10 @@ class ConfigurationResolverTest extends TestCase
             ->method('getDefaultValue')
             ->willReturn('foo');
 
+        $this->configurationOne
+            ->method('supportsClient')
+            ->willReturn(true);
+
         $rawConfiguration = (new RawConfiguration())
             ->addConfiguration($this->configurationOne);
 
@@ -66,6 +70,10 @@ class ConfigurationResolverTest extends TestCase
             ->method('cast')
             ->willReturn(1);
 
+        $this->configurationThree
+            ->method('supportsClient')
+            ->willReturn(true);
+
         $rawConfiguration = (new RawConfiguration())
             ->addConfiguration($this->configurationThree);
 
@@ -77,6 +85,10 @@ class ConfigurationResolverTest extends TestCase
 
     public function testWrongClientException(): void
     {
+        $this->configurationOne
+            ->method('supportsClient')
+            ->willReturn(true);
+
         $rawConfiguration = (new RawConfiguration())
             ->addConfiguration($this->configurationOne);
 
@@ -94,6 +106,10 @@ class ConfigurationResolverTest extends TestCase
 
         $this->configurationOne
             ->method('isValueValid')
+            ->willReturn(true);
+
+        $this->configurationOne
+            ->method('supportsClient')
             ->willReturn(true);
 
         $this->input
@@ -122,6 +138,10 @@ class ConfigurationResolverTest extends TestCase
         $this->configurationOne
             ->method('isValueValid')
             ->willReturn(false);
+
+        $this->configurationOne
+            ->method('supportsClient')
+            ->willReturn(true);
 
         $this->input
             ->method('getParameterOption')
@@ -152,6 +172,10 @@ class ConfigurationResolverTest extends TestCase
             ->method('isValueValid')
             ->willReturn(true);
 
+        $this->configurationOne
+            ->method('supportsClient')
+            ->willReturn(true);
+
         $rawConfiguration = (new RawConfiguration())
             ->addConfiguration($this->configurationOne);
 
@@ -170,6 +194,10 @@ class ConfigurationResolverTest extends TestCase
         $this->configurationOne
             ->method('isValueValid')
             ->willReturn(false);
+
+        $this->configurationOne
+            ->method('supportsClient')
+            ->willReturn(true);
 
         $rawConfiguration = (new RawConfiguration())
             ->addConfiguration($this->configurationOne);
@@ -190,6 +218,10 @@ class ConfigurationResolverTest extends TestCase
 
         $this->configurationOne
             ->method('isValueValid')
+            ->willReturn(true);
+
+        $this->configurationOne
+            ->method('supportsClient')
             ->willReturn(true);
 
         $rawConfiguration = (new RawConfiguration())


### PR DESCRIPTION
Good day! Thanks for the bundle! It looks really great! 👍

This patch provides a solution to divide configurations between producers and consumers. Without this patch bundle collects all configs for both producers and consumers, which in turn leads to kafka warnings, that sounds like "configuration X parameter is not intended for producer and so will be ignored".