### PR TITLE
Allow ^3.0 for flix-tech/avro-serde-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "symfony/http-kernel": "^6.4|^7.0",
     "symfony/console": "^6.4|^7.0",
     "symfony/options-resolver": "^6.4|^7.0",
-    "flix-tech/avro-serde-php": "^2.0"
+    "flix-tech/avro-serde-php": "^2.0|^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hello and thanks for a great package.

It turns out that Symfony 7.x support was added to `flix-tech/avro-serde-php` since version 3.0: https://github.com/flix-tech/avro-serde-php/releases/tag/3.0.0

But current requirement is `"flix-tech/avro-serde-php": "^2.0"`

So, our project stuck with this incompatibility during integration of Symfony 7 support:

`Fatal error: Declaration of FlixTech\AvroSerializer\Integrations\Symfony\Serializer\AvroSerDeEncoder::decode(int $data, int $format, array $context = []): mixed must be compatible with Symfony\Component\Serializer\Encoder\DecoderInterface::decode(string $data, string $format, array $context = []) in /var/app/vendor/flix-tech/avro-serde-php/integrations/Symfony/Serializer/AvroSerDeEncoder.php on line 35`

which is resolved in `flix-tech/avro-serde-php` 3.0

I checked that phpunit tests work fine.